### PR TITLE
Added 1 dong = 100 xu minor value

### DIFF
--- a/src/vnd.json5
+++ b/src/vnd.json5
@@ -10,10 +10,20 @@
                 "name": "dong",
                 "symbol": "₫"
             },
+            // Offically, dong has two minor values, just like CNY
+            // 1 dong = 10 hao
+            // 1 dong = 100 xu
+            // Both are not being accepted in retail since 2004
+            // If at all, use xu instead of hao as the preferred minor value
             "minor": {
-                "name": "Hào",
+                "name": "xu",
                 "symbol": "",
                 "majorValue": 0.01
+            }
+            "minor2": {
+                "name": "Hào",
+                "symbol": "",
+                "majorValue": 0.1
             }
         },
         "banknotes": {


### PR DESCRIPTION
Just like for chinese renmimbi (CNY), there are two minor unit for vietnamese dong. This should be reflected in here. However, both minor units are not accepted since 2004 in retail. So, it's debatable whether to keep them at all in here.
https://en.wikipedia.org/wiki/Vietnamese_%C4%91%E1%BB%93ng