### PR TITLE
1 khoums = 1/5 Ouguiya

### DIFF
--- a/src/mro.json5
+++ b/src/mro.json5
@@ -13,7 +13,9 @@
             "minor": {
                 "name": "khoums",
                 "symbol": "",
-                "majorValue": 0.01
+                // 1 khoums = 1/5 Ouguiya
+                // https://en.wikipedia.org/wiki/Mauritanian_ouguiya
+                "majorValue": 0.2
             }
         },
         "banknotes": {


### PR DESCRIPTION
The minor value khoums is 1/5 of the major value, so the minor vs major value in the declaration was wrong.
Pleaes look at https://en.wikipedia.org/wiki/Mauritanian_ouguiya