### PR TITLE
Change VUV majorValue for better compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#Currency information in JSON.
+# Currency information in JSON.
 This repository contains currency information for currencies contained in ISO 4217 in JSON format.
 
-##Example
+## Example
 
 ```json
 {

--- a/dist/json/countries/vuv.json
+++ b/dist/json/countries/vuv.json
@@ -13,7 +13,7 @@
             "minor": {
                 "name": "",
                 "symbol": "",
-                "majorValue": ""
+                "majorValue": 1.0
             }
         },
         "banknotes": {

--- a/dist/json/currencies.json
+++ b/dist/json/currencies.json
@@ -5969,7 +5969,7 @@
 			"minor": {
 				"name": "",
 				"symbol": "",
-				"majorValue": ""
+				"majorValue": 1.0
 			}
 		},
 		"banknotes": {

--- a/src/vuv.json5
+++ b/src/vuv.json5
@@ -13,7 +13,7 @@
             "minor": {
                 "name": "",
                 "symbol": "",
-                "majorValue": "",
+                "majorValue": 1.0,
             }
         },
         "banknotes": {


### PR DESCRIPTION
I propose changing the `majorValue` of the VUV currency to be in consistent format with all other values. All those values are currently represented as floating point numbers.

The only exception is VUV which does not really have a minor unit. This is currently represented as an empty string `""`, but that could cause compatibility issues. (At least it has for me).

I would like to use the value `1.0` to indicate that the minor unit is the same as the major unit. This is more consistent with the logic of the other values.

Also I fixed the formatting of the README header.